### PR TITLE
Fix #26: Increased Ring Buffer Size

### DIFF
--- a/cores/arduino/RingBuffer.h
+++ b/cores/arduino/RingBuffer.h
@@ -25,7 +25,7 @@
 // using a ring buffer (I think), in which head is the index of the location
 // to which to write the next incoming character and tail is the index of the
 // location from which to read.
-#define SERIAL_BUFFER_SIZE 164
+#define SERIAL_BUFFER_SIZE 256
 
 class RingBuffer
 {


### PR DESCRIPTION
Increased the serial buffer size to 256 and able to read 125 registers from a Modbus device.