### PR TITLE
Revert rename au915 to au921

### DIFF
--- a/boards.template
+++ b/boards.template
@@ -93,7 +93,7 @@ menu.lorawan_region=LoRaWAN Region
 # menu.lorawan_region
 {{board}}.menu.lorawan_region.us915=North America 915 MHz
 {{board}}.menu.lorawan_region.eu868=Europe 868 MHz
-{{board}}.menu.lorawan_region.au921=Australia 921 MHz
+{{board}}.menu.lorawan_region.au915=Australia 915 MHz
 {{board}}.menu.lorawan_region.as923=Asia 923 MHz
 {{board}}.menu.lorawan_region.as923jp=Japan 923 MHz
 {{board}}.menu.lorawan_region.kr920=Korea 920 MHz
@@ -101,7 +101,7 @@ menu.lorawan_region=LoRaWAN Region
 {{board}}.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 {{board}}.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 {{board}}.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-{{board}}.menu.lorawan_region.au921.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+{{board}}.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 {{board}}.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 {{board}}.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 {{board}}.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h

--- a/boards.txt
+++ b/boards.txt
@@ -63,7 +63,7 @@ mcci_catena_4410.bootloader.file=feather/samd21_sam_ba.bin
 # menu.lorawan_region
 mcci_catena_4410.menu.lorawan_region.us915=North America 915 MHz
 mcci_catena_4410.menu.lorawan_region.eu868=Europe 868 MHz
-mcci_catena_4410.menu.lorawan_region.au921=Australia 921 MHz
+mcci_catena_4410.menu.lorawan_region.au915=Australia 915 MHz
 mcci_catena_4410.menu.lorawan_region.as923=Asia 923 MHz
 mcci_catena_4410.menu.lorawan_region.as923jp=Japan 923 MHz
 mcci_catena_4410.menu.lorawan_region.kr920=Korea 920 MHz
@@ -71,7 +71,7 @@ mcci_catena_4410.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4410.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4410.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4410.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -112,7 +112,7 @@ mcci_catena_4420.bootloader.file=feather/samd21_sam_ba.bin
 # menu.lorawan_region
 mcci_catena_4420.menu.lorawan_region.us915=North America 915 MHz
 mcci_catena_4420.menu.lorawan_region.eu868=Europe 868 MHz
-mcci_catena_4420.menu.lorawan_region.au921=Australia 921 MHz
+mcci_catena_4420.menu.lorawan_region.au915=Australia 915 MHz
 mcci_catena_4420.menu.lorawan_region.as923=Asia 923 MHz
 mcci_catena_4420.menu.lorawan_region.as923jp=Japan 923 MHz
 mcci_catena_4420.menu.lorawan_region.kr920=Korea 920 MHz
@@ -120,7 +120,7 @@ mcci_catena_4420.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4420.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4420.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4420.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -161,7 +161,7 @@ mcci_catena_4450.bootloader.file=feather/samd21_sam_ba.bin
 # menu.lorawan_region
 mcci_catena_4450.menu.lorawan_region.us915=North America 915 MHz
 mcci_catena_4450.menu.lorawan_region.eu868=Europe 868 MHz
-mcci_catena_4450.menu.lorawan_region.au921=Australia 921 MHz
+mcci_catena_4450.menu.lorawan_region.au915=Australia 915 MHz
 mcci_catena_4450.menu.lorawan_region.as923=Asia 923 MHz
 mcci_catena_4450.menu.lorawan_region.as923jp=Japan 923 MHz
 mcci_catena_4450.menu.lorawan_region.kr920=Korea 920 MHz
@@ -169,7 +169,7 @@ mcci_catena_4450.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4450.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4450.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4450.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -210,7 +210,7 @@ mcci_catena_4460.bootloader.file=feather/samd21_sam_ba.bin
 # menu.lorawan_region
 mcci_catena_4460.menu.lorawan_region.us915=North America 915 MHz
 mcci_catena_4460.menu.lorawan_region.eu868=Europe 868 MHz
-mcci_catena_4460.menu.lorawan_region.au921=Australia 921 MHz
+mcci_catena_4460.menu.lorawan_region.au915=Australia 915 MHz
 mcci_catena_4460.menu.lorawan_region.as923=Asia 923 MHz
 mcci_catena_4460.menu.lorawan_region.as923jp=Japan 923 MHz
 mcci_catena_4460.menu.lorawan_region.kr920=Korea 920 MHz
@@ -218,7 +218,7 @@ mcci_catena_4460.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4460.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4460.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4460.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -259,7 +259,7 @@ mcci_catena_4470.bootloader.file=feather/samd21_sam_ba.bin
 # menu.lorawan_region
 mcci_catena_4470.menu.lorawan_region.us915=North America 915 MHz
 mcci_catena_4470.menu.lorawan_region.eu868=Europe 868 MHz
-mcci_catena_4470.menu.lorawan_region.au921=Australia 921 MHz
+mcci_catena_4470.menu.lorawan_region.au915=Australia 915 MHz
 mcci_catena_4470.menu.lorawan_region.as923=Asia 923 MHz
 mcci_catena_4470.menu.lorawan_region.as923jp=Japan 923 MHz
 mcci_catena_4470.menu.lorawan_region.kr920=Korea 920 MHz
@@ -267,7 +267,7 @@ mcci_catena_4470.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4470.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4470.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4470.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h

--- a/boards.txt
+++ b/boards.txt
@@ -71,7 +71,7 @@ mcci_catena_4410.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4410.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4410.menu.lorawan_region.au921.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4410.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4410.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -120,7 +120,7 @@ mcci_catena_4420.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4420.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4420.menu.lorawan_region.au921.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4420.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4420.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -169,7 +169,7 @@ mcci_catena_4450.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4450.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4450.menu.lorawan_region.au921.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4450.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4450.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -218,7 +218,7 @@ mcci_catena_4460.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4460.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4460.menu.lorawan_region.au921.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4460.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4460.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
@@ -267,7 +267,7 @@ mcci_catena_4470.menu.lorawan_region.in866=India 866 MHz
 mcci_catena_4470.menu.lorawan_region.projcfg=Use arduino-lmic/project_confic/lmic_project_lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.us915.build.lorawan_flags=-DCFG_us915=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.eu868.build.lorawan_flags=-DCFG_eu868=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
-mcci_catena_4470.menu.lorawan_region.au921.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
+mcci_catena_4470.menu.lorawan_region.au915.build.lorawan_flags=-DCFG_au921=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.as923.build.lorawan_flags=-DCFG_as923=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.as923jp.build.lorawan_flags=-DCFG_as923=1 -DLMIC_COUNTRY_CODE=LMIC_COUNTRY_CODE_JP -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h
 mcci_catena_4470.menu.lorawan_region.kr920.build.lorawan_flags=-DCFG_kr920=1 -DCFG_sx1276_radio=1 -DARDUINO_LMIC_PROJECT_CONFIG_H=lmic_config_preconditions.h


### PR DESCRIPTION
This reverts commit 21fba2e91d2825840ea48ba15a8d5a874977b054, which renamed AU915 (correct) to AU921 (incorrect).

Also related to mcci-catena/arduino-lmic#363.